### PR TITLE
fix: file name matching

### DIFF
--- a/src/graph-loader.ts
+++ b/src/graph-loader.ts
@@ -1,8 +1,35 @@
 import type { ComponentKey, ComponentRegistry } from './registry'
 import { type Edge, Node } from './node'
 import { readFileSync } from 'node:fs'
-import { parseComponent, compile, type ASTNode } from 'vue-template-compiler'
+import { parseComponent, compile, type ASTNode, type ASTElement } from 'vue-template-compiler'
 import { consola } from 'consola'
+import type { VueFileName } from './util'
+
+/**
+ * Convert a text from kebab-case to CamelCase
+ */
+function toUpperCamelCase<S extends string>(text: S): Capitalize<S> {
+  const capitalizeWord = (word: string): Capitalize<S> => {
+    let capitalized = ''
+    for (let i = 0; i< word.length; i++) {
+      const char = i === 0 ? word[i].toUpperCase() : word[i]
+      capitalized += char
+    }
+    return capitalized as Capitalize<S>
+  }
+
+  // from kebab-case
+  return text.split('-').map((word) => capitalizeWord(word)).join('') as Capitalize<S>
+}
+
+/**
+ * Convert a text from CamelCase to kebab-case
+ */
+function toKebabCase(text: string): string {
+  return text
+    .replace(/^ *?[A-Z]/, (str) => str.toLowerCase())
+    .replace(/ *?[A-Z]/g, (str) => `-${str.replace(/ /g, '').toLowerCase()}`)
+}
 
 /**
  * Graph loader starting from a root node
@@ -12,19 +39,7 @@ export class GraphLoader {
 
   // FIXME: Maybe non-side-effect functioning
   load(node: Node): void {
-    const filePath = this.registry.get(node.name)
-    if (!filePath) {
-      consola.warn(`${node.name} does not found in directory`)
-      return
-    }
-
-    const vueContentBuf = readFileSync(filePath)
-    // Extract template source and convert to AST elements
-    const { template } = parseComponent(vueContentBuf.toString())
-    if (!template) return
-
-    const { ast } = compile(template.content)
-    // Compile to `undefined` when the template is empty
+    const ast = this.getAstOrNull(node)
     if (!ast) return
 
     const tags = [
@@ -45,6 +60,39 @@ export class GraphLoader {
         this.load(pair[1])
       }
     }
+  }
+
+  /**
+   * Return AST of a Node reading a relevant file
+   */
+  private getAstOrNull(node: Node): ASTElement | undefined {
+    // Check matching by kebab-case or UpperCamelCase
+    const filePath = this.searchFilePath(node.name)
+    if (!filePath) {
+      consola.warn(`${node.name} does not found in directory`)
+      return
+    }
+
+    const vueContentBuf = readFileSync(filePath)
+    // Extract template source and convert to AST elements
+    const { template } = parseComponent(vueContentBuf.toString())
+    if (!template) return
+
+    const { ast } = compile(template.content)
+    return ast
+  }
+
+  /**
+   * Get file path matching by `camelized` or `kebabified` key of original component name
+   */
+  searchFilePath(name: string): VueFileName | undefined {
+    // Check matching by kebab-case or UpperCamelCase
+    const matchedKey = Array.from(
+      [toUpperCamelCase(name), toKebabCase(name), name]
+    ).find((n) => !!this.registry.get(n))
+    if (!matchedKey) return
+
+    return this.registry.get(matchedKey)
   }
 
   /**

--- a/src/graph-loader.ts
+++ b/src/graph-loader.ts
@@ -3,7 +3,7 @@ import { type Edge, Node } from './node'
 import { readFileSync } from 'node:fs'
 import { parseComponent, compile, type ASTNode, type ASTElement } from 'vue-template-compiler'
 import { consola } from 'consola'
-import type { VueFileName } from './util'
+import type { KebabCase, VueFileName } from './util'
 
 /**
  * Convert a text from kebab-case to CamelCase
@@ -24,11 +24,13 @@ function toUpperCamelCase<S extends string>(text: S): Capitalize<S> {
 
 /**
  * Convert a text from CamelCase to kebab-case
+ * NOTE: if required this from other files, move to util
  */
-function toKebabCase(text: string): string {
+function toKebabCase<S extends string>(text: S): KebabCase<S> {
+  // Force casting `KebabCase<S>` as result must be kebab-case
   return text
     .replace(/^ *?[A-Z]/, (str) => str.toLowerCase())
-    .replace(/ *?[A-Z]/g, (str) => `-${str.replace(/ /g, '').toLowerCase()}`)
+    .replace(/ *?[A-Z]/g, (str) => `-${str.replace(/ /g, '').toLowerCase()}`) as KebabCase<S>
 }
 
 /**

--- a/src/graph-loader.ts
+++ b/src/graph-loader.ts
@@ -10,12 +10,9 @@ import type { KebabCase, VueFileName } from './util'
  */
 function toUpperCamelCase<S extends string>(text: S): Capitalize<S> {
   const capitalizeWord = (word: string): Capitalize<S> => {
-    let capitalized = ''
-    for (let i = 0; i< word.length; i++) {
-      const char = i === 0 ? word[i].toUpperCase() : word[i]
-      capitalized += char
-    }
-    return capitalized as Capitalize<S>
+    return Array.from(word)
+      .map((char, index) => index === 0 ? char.toUpperCase() : char.toLowerCase())
+      .reduce((result, char) => result + char) as Capitalize<S>
   }
 
   // from kebab-case

--- a/src/graph-loader.ts
+++ b/src/graph-loader.ts
@@ -65,7 +65,6 @@ export class GraphLoader {
    * Return AST of a Node reading a relevant file
    */
   private getAstOrNull(node: Node): ASTElement | undefined {
-    // Check matching by kebab-case or UpperCamelCase
     const filePath = this.searchFilePath(node.name)
     if (!filePath) {
       consola.warn(`${node.name} does not found in directory`)
@@ -85,7 +84,6 @@ export class GraphLoader {
    * Get file path matching by `camelized` or `kebabified` key of original component name
    */
   searchFilePath(name: string): VueFileName | undefined {
-    // Check matching by kebab-case or UpperCamelCase
     const matchedKey = Array.from(
       [toUpperCamelCase(name), toKebabCase(name), name]
     ).find((n) => !!this.registry.get(n))

--- a/src/util.ts
+++ b/src/util.ts
@@ -70,3 +70,16 @@ export function textAlign(text: string, offset: number, align: TextAlign): strin
 
   return align === 'left' ? `${text}${padding}` : `${padding}${text}`
 }
+
+type Concatenation<
+  Strs extends string[],
+  Separator extends string = '',
+  Result extends string = ''
+> = Strs extends [(infer Head extends string), ...(infer Rest extends string[])]
+? Result extends ''
+  ? Concatenation<Rest, Separator, `${Head}`>
+  : Concatenation<Rest, Separator, `${Result}${Separator}${Head}`>
+: Result
+
+type KebabCase<Strs extends string[]> = Concatenation<Strs, '-'>
+

--- a/src/util.ts
+++ b/src/util.ts
@@ -71,15 +71,8 @@ export function textAlign(text: string, offset: number, align: TextAlign): strin
   return align === 'left' ? `${text}${padding}` : `${padding}${text}`
 }
 
-type Concatenation<
-  Strs extends string[],
-  Separator extends string = '',
-  Result extends string = ''
-> = Strs extends [(infer Head extends string), ...(infer Rest extends string[])]
-? Result extends ''
-  ? Concatenation<Rest, Separator, `${Head}`>
-  : Concatenation<Rest, Separator, `${Result}${Separator}${Head}`>
-: Result
-
-type KebabCase<Strs extends string[]> = Concatenation<Strs, '-'>
-
+export type KebabCase<S extends string> = S extends `${infer S1}${infer S2}`
+? S2 extends Uncapitalize<S2>
+  ? `${Uncapitalize<S1>}${KebabCase<S2>}`
+  : `${Uncapitalize<S1>}-${KebabCase<S2>}`
+: S

--- a/test/graph-loader.test.ts
+++ b/test/graph-loader.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
   mockFs.restore()
 })
 
-describe('GraphLoader', () => {
+describe('GraphLoader#load', () => {
   describe('when the node name does not map to any element', () => {
     const registry = new MockComponentRegistry({})
     const loader = new GraphLoader(registry)
@@ -147,6 +147,162 @@ describe('GraphLoader', () => {
       expect(root.edges.App.edges.DeleteButton.edges.Button).toBeDefined()
       expect(root.edges.App.edges.UpdateButton).toBeDefined()
       expect(root.edges.App.edges.UpdateButton.edges.Button).toBeDefined()
+    })
+  })
+})
+
+describe('GraphLoader#searchFilePath', () => {
+  describe('when components name is camel case', () => {
+    const registry = new MockComponentRegistry({
+      'App': 'components/App.vue',
+      'AddCardButton': 'components/AddCardButton.vue',
+      'DeleteCardButton': 'components/DeleteCardButton.vue',
+      'pages/index.vue': 'pages/index.vue'
+    })
+    beforeEach(() => {
+      mockFs({
+        'components': {
+          'App.vue': `
+<template>
+  <section>
+    <p>Add card</p>
+    <AddCardButton />
+    <p>Delete card</p>
+    <DeleteCardButton />
+  </section>
+</template>
+`
+        },
+        'pages': {
+          'index.vue': '<template><App /></template>'
+        }
+      })
+    })
+    const loader = new GraphLoader(registry)
+
+    it('should match in the registry', () => {
+      const addCardButton = loader.searchFilePath('AddCardButton')
+      const deleteCardButton = loader.searchFilePath('DeleteCardButton')
+
+      expect(addCardButton).toBe('components/AddCardButton.vue')
+      expect(deleteCardButton).toBe('components/DeleteCardButton.vue')
+    })
+  })
+
+  describe('when components name is kebab case', () => {
+    const registry = new MockComponentRegistry({
+      'app': 'components/app.vue',
+      'add-card-button': 'components/add-card-button.vue',
+      'delete-card-button': 'components/delete-card-button.vue',
+      'pages/index.vue': 'pages/index.vue'
+    })
+    beforeEach(() => {
+      mockFs({
+        'components': {
+          'App.vue': `
+<template>
+  <section>
+    <p>Add card</p>
+    <add-card-button />
+    <p>Delete card</p>
+    <delete-card-button />
+  </section>
+</template>
+`
+        },
+        'pages': {
+          'index.vue': '<template><app /></template>'
+        }
+      })
+    })
+    const loader = new GraphLoader(registry)
+
+    it('should match in the registry', () => {
+      const addCardButton = loader.searchFilePath('add-card-button')
+      const deleteCardButton = loader.searchFilePath('delete-card-button')
+
+      expect(addCardButton).toBe('components/add-card-button.vue')
+      expect(deleteCardButton).toBe('components/delete-card-button.vue')
+    })
+  })
+
+  describe('when components name in templates is camel case and files are kebab case', () => {
+    const registry = new MockComponentRegistry({
+      'app': 'components/app.vue',
+      'add-card-button': 'components/add-card-button.vue',
+      'delete-card-button': 'components/delete-card-button.vue',
+      'pages/index.vue': 'pages/index.vue'
+    })
+    beforeEach(() => {
+      mockFs({
+        'components': {
+          'App.vue': `
+<template>
+  <section>
+    <p>Add card</p>
+    <AddCardButton />
+    <p>Delete card</p>
+    <DeleteCardButton />
+  </section>
+</template>
+`
+        },
+        'pages': {
+          'index.vue': '<template><App /></template>'
+        }
+      })
+    })
+    const loader = new GraphLoader(registry)
+
+    it('should match in the registry', () => {
+      // Loader specify node name by names in template
+      const app = loader.searchFilePath('App')
+      const addCardButton = loader.searchFilePath('AddCardButton')
+      const deleteCardButton = loader.searchFilePath('DeleteCardButton')
+
+      expect(app).toBe('components/app.vue')
+      expect(addCardButton).toBe('components/add-card-button.vue')
+      expect(deleteCardButton).toBe('components/delete-card-button.vue')
+    })
+  })
+
+  describe('when components name in templates is kebab case and files are camel case', () => {
+    const registry = new MockComponentRegistry({
+      'App': 'components/App.vue',
+      'AddCardButton': 'components/AddCardButton.vue',
+      'DeleteCardButton': 'components/DeleteCardButton.vue',
+      'pages/index.vue': 'pages/index.vue'
+    })
+    beforeEach(() => {
+      mockFs({
+        'components': {
+          'App.vue': `
+<template>
+  <section>
+    <p>Add card</p>
+    <add-card-button />
+    <p>Delete card</p>
+    <delete-card-button />
+  </section>
+</template>
+`
+        },
+        'pages': {
+          'index.vue': '<template><app /></template>'
+        }
+      })
+    })
+    const loader = new GraphLoader(registry)
+
+    it('should match in the registry', () => {
+      // Loader specify node name by names in template
+      const app = loader.searchFilePath('app')
+      const addCardButton = loader.searchFilePath('add-card-button')
+      const deleteCardButton = loader.searchFilePath('delete-card-button')
+
+      expect(app).toBe('components/App.vue')
+      expect(addCardButton).toBe('components/AddCardButton.vue')
+      expect(deleteCardButton).toBe('components/DeleteCardButton.vue')
     })
   })
 })


### PR DESCRIPTION
# Overview

Based on Style guide of Vue.js 2, improve to match component names in template with kebab case or upper case case.

- [Style Guide](https://v2.vuejs.org/v2/style-guide/?redirect=true#Priority-B-Rules-Strongly-Recommended-Improving-Readability)

## Design

- convert node names to kebab case and upper case
- find first matching in those formats


