### PR TITLE
refactor: Make printer formatter DRY

### DIFF
--- a/src/commands/load-all.ts
+++ b/src/commands/load-all.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty'
-import { createPrinter, getPrinterType } from '../printer'
+import { createPrinter, PrinterFormat } from '../printer'
 import { consola } from 'consola'
 import { colorize } from 'consola/utils'
 import { readDirDeepSyncAsPaths, setupComponentRegistry } from '../registry'
@@ -29,7 +29,6 @@ export default defineCommand({
   run({ args }) {
     const viewsDir = args.viewsDir
     const componentsDir = args.componentsDir
-    const printerType = getPrinterType(args.format as string)
 
     consola.info(
       `Traversing "${colorize('blue', viewsDir)}" associated with "${colorize('blue', componentsDir)}"`
@@ -49,7 +48,8 @@ export default defineCommand({
       rootNodes.push(rootNode)
     }
 
-    createPrinter(registry, printerType)
+    const printerFormat = new PrinterFormat(args.format as string)
+    createPrinter(registry, printerFormat.type)
       .onCompleted(() => {
         consola.success(colorize('green', `Analysis succeeded for: ${viewsDir}`))
       })

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -2,7 +2,7 @@ import { defineCommand } from 'citty'
 import { Node } from '../node'
 import { setupComponentRegistry } from '../registry'
 import { vueFileNameOrThrow } from '../util'
-import { createPrinter, getPrinterType } from '../printer'
+import { createPrinter, PrinterFormat } from '../printer'
 import { GraphLoader } from '../graph-loader'
 import { consola } from 'consola'
 import { colorize } from 'consola/utils'
@@ -29,7 +29,6 @@ export default defineCommand({
   run({ args }) {
     const fileName = args.pageFileName
     const componentsDir = args.componentsDir
-    const printerType = getPrinterType(args.format as string)
     const vueFileName = vueFileNameOrThrow(fileName)
 
     consola.info(
@@ -44,7 +43,8 @@ export default defineCommand({
     const rootNode = new Node(vueFileName)
     new GraphLoader(registry).load(rootNode)
 
-    createPrinter(registry, printerType)
+    const printerFormat = new PrinterFormat(args.format as string)
+    createPrinter(registry, printerFormat.type)
       .onCompleted(() => {
         consola.success(colorize('green', `Analysis succeeded for: ${vueFileName}`))
       })

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -5,13 +5,21 @@ import { ConsolePrinter, VisualGraphPrinter, StatisticsReportPrinter } from './p
 type PrinterType = 'stdout' | 'graph' | 'report'
 
 /**
- * Assert and safe cast to `PrinterType`
+ * Printer type formatter, set default as 'graph'
  */
-export function getPrinterType(type: string): PrinterType {
-  if (type === 'stdout' || type === 'graph' || type === 'report') {
-    return type as PrinterType
+export class PrinterFormat {
+  private readonly types = ['stdout', 'graph', 'report']
+  private readonly _type: PrinterType
+
+  constructor (private _value: string | undefined) {
+    this._type = this.types.includes(this._value)
+      ? (this._value as PrinterType)
+      : 'graph'    
   }
-  return 'graph'
+
+  get type(): PrinterType {
+    return this._type
+  }
 }
 
 export interface Printer {
@@ -23,7 +31,7 @@ export interface Printer {
 /**
  * Factory method of `Printer` s.
  */
-export function createPrinter(registry: ComponentRegistry, type: PrinterType | undefined = 'stdout'): Printer {
+export function createPrinter(registry: ComponentRegistry, type: PrinterType): Printer {
   let printerConstructor: new (registry: ComponentRegistry) => Printer
   switch (type) {
     case 'graph':


### PR DESCRIPTION
# Overview

Tiny refactoring: fixing printer formatting to make DRY. Make default 'graph' .